### PR TITLE
fix MusicBrainz DiscID calculation

### DIFF
--- a/src/music_brainz/calculate_id.rs
+++ b/src/music_brainz/calculate_id.rs
@@ -3,6 +3,7 @@ use sha1::{Digest, Sha1};
 
 use cd_da_reader::Toc;
 
+/// read more about the algorithm here: https://musicbrainz.org/doc/Disc_ID_Calculation
 pub fn calculate_music_brainz_id(toc: &Toc) -> String {
     let toc_string = format_toc_string(toc);
 
@@ -16,7 +17,7 @@ pub fn calculate_music_brainz_id(toc: &Toc) -> String {
     base64_result
         .replace('+', ".")
         .replace('/', "_")
-        .trim_end_matches('=')
+        .replace('=', "-")
         .to_string()
 }
 

--- a/src/music_brainz/fetch_metadata.rs
+++ b/src/music_brainz/fetch_metadata.rs
@@ -7,8 +7,7 @@ use ureq;
 
 #[derive(Debug, Deserialize)]
 pub struct MusicBrainzResponse {
-    pub releases: Option<Vec<Release>>,
-    pub release: Option<Release>,
+    pub releases: Option<Vec<Release>>
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,7 +63,7 @@ impl MusicBrainzClient {
         id: &str,
         includes: &[&str],
     ) -> Result<MusicBrainzResponse, MusicBrainzError> {
-        let mut url = format!("https://musicbrainz.org/ws/2/discid/{}-", id);
+        let mut url = format!("https://musicbrainz.org/ws/2/discid/{}", id);
 
         if !includes.is_empty() {
             url.push_str(&format!("&inc={}", includes.join("+")));


### PR DESCRIPTION
## Description

The previous implementation had an issue where I dropped `=` completely, but it only needs to be replaced with `-` ([ref](https://musicbrainz.org/doc/Disc_ID_Calculation)):

> Important note: The Base64 encoding used by MusicBrainz is not the same one as specified in [RFC 4648](https://tools.ietf.org/html/rfc4648). The specification uses +, /, and = characters, all of which are special HTTP/URL characters. To avoid the problems with dealing with that, MusicBrainz uses ., _, and - instead. For details on this, please refer to [base64.c](https://github.com/metabrainz/libdiscid/blob/master/src/base64.c) in the [libdiscid source code](https://github.com/metabrainz/libdiscid).

So I keep it and also link the algorithm itself.