### PR TITLE
set FLAC metadata

### DIFF
--- a/src/album_writer.rs
+++ b/src/album_writer.rs
@@ -4,12 +4,13 @@ use std::io::Result;
 use std::io::Write;
 use std::path::PathBuf;
 
-use crate::music_brainz::Album;
+use crate::music_brainz::{Album, AlbumTrack};
 use cd_da_reader::{CdReader, Toc};
 
 use flac_codec::{
     byteorder::LittleEndian,
     encode::{FlacByteWriter, Options},
+    metadata::{VorbisComment, update},
 };
 
 pub fn write_album(album: &Album, reader: &CdReader, toc: &Toc) -> Result<()> {
@@ -22,13 +23,18 @@ pub fn write_album(album: &Album, reader: &CdReader, toc: &Toc) -> Result<()> {
     for track in &album.tracks {
         let track_num = track.num.try_into().unwrap();
         let track_data = reader.read_track(toc, track_num)?;
-        save_raw_data_as_flac(new_dir.join(&track.title), track_data);
+        save_raw_data_as_flac(new_dir.join(&track.title), track_data, track, album);
     }
 
     Ok(())
 }
 
-pub fn save_raw_data_as_flac(file_path: PathBuf, data: Vec<u8>) -> Option<()> {
+fn save_raw_data_as_flac(
+    file_path: PathBuf,
+    data: Vec<u8>,
+    track: &AlbumTrack,
+    album: &Album,
+) -> Option<()> {
     let file = file_path.with_extension("flac");
 
     if file.exists() {
@@ -41,18 +47,50 @@ pub fn save_raw_data_as_flac(file_path: PathBuf, data: Vec<u8>) -> Option<()> {
     let bits_per_sample = 16u32;
     let channels = 2u8;
 
-    let mut flac_writer: FlacByteWriter<std::io::BufWriter<fs::File>, LittleEndian> =
-        FlacByteWriter::create(
-            file,
-            Options::best(),
-            sample_rate,
-            bits_per_sample,
-            channels,
-            None,
-        )
-        .unwrap();
+    {
+        let mut flac_writer: FlacByteWriter<std::io::BufWriter<fs::File>, LittleEndian> =
+            FlacByteWriter::create(
+                &file,
+                Options::best(),
+                sample_rate,
+                bits_per_sample,
+                channels,
+                None,
+            )
+            .unwrap();
 
-    flac_writer.write_all(&data).ok()?;
+        flac_writer.write_all(&data).ok()?;
+
+        flac_writer.finalize().ok()?;
+    }
+
+    match update_track_metadata(&file, track, album) {
+        Ok(_) => {
+            println!("Successfully added metadata");
+        }
+        Err(flac_error) => {
+            println!("{:#?}", flac_error);
+        }
+    };
 
     Some(())
+}
+
+fn update_track_metadata(
+    file_path: &PathBuf,
+    track: &AlbumTrack,
+    album: &Album,
+) -> std::result::Result<bool, flac_codec::Error> {
+    update(file_path, |blocklist| {
+        blocklist.update::<VorbisComment>(|vorbis_comment| {
+            vorbis_comment.set("TITLE", &track.title);
+            vorbis_comment.set("ALBUM", &album.title);
+            vorbis_comment.set("ARTIST", &album.artist);
+            vorbis_comment.set("TRACKNUMBER", track.num);
+            vorbis_comment.set("DATE", &album.date);
+            vorbis_comment.set("COUNTRY", &album.country);
+        });
+
+        Ok::<(), flac_codec::Error>(())
+    })
 }

--- a/src/music_brainz.rs
+++ b/src/music_brainz.rs
@@ -1,4 +1,4 @@
 mod calculate_id;
 mod fetch_metadata;
 
-pub use fetch_metadata::{MusicBrainzClient, Album};
+pub use fetch_metadata::{MusicBrainzClient, Album, AlbumTrack};


### PR DESCRIPTION
## Description

Add metadata to FLAC using [Vorbis comments](https://en.wikipedia.org/wiki/Vorbis_comment) -- artist, track title, track number, album name, release date.

## Reference

Closes https://github.com/Bloomca/audio-cd-ripper/issues/6