### PR TITLE
add progress prints

### DIFF
--- a/src/music_brainz/fetch_metadata.rs
+++ b/src/music_brainz/fetch_metadata.rs
@@ -146,13 +146,7 @@ impl MusicBrainzClient {
         let result = self.lookup_by_disc_id(&id, &includes);
 
         match result {
-            Ok(response) => {
-                let album_data: Option<Album> = self.parse_metadata(&response);
-
-                println!("{:#?}", album_data);
-
-                album_data
-            }
+            Ok(response) => self.parse_metadata(&response),
             Err(error) => {
                 println!("{:#?}", error);
 

--- a/src/read_drive.rs
+++ b/src/read_drive.rs
@@ -1,5 +1,5 @@
 use std::io::{Result, Error};
-use crate::music_brainz::MusicBrainzClient;
+use crate::music_brainz::{Album, MusicBrainzClient};
 use crate::album_writer::write_album;
 
 use cd_da_reader::CdReader;
@@ -16,8 +16,15 @@ pub fn read_drive(letter: &str) -> Result<()> {
         return Err(Error::other("could not get album data"));
     };
 
+    print_album_info(&album);
+
     write_album(&album, &reader, &toc)?;
 
     Ok(())
+}
+
+fn print_album_info(album: &Album) {
+    println!("Found album {} by {} from {}, {} release", album.title, album.artist, album.date, album.country);
+    println!("There are {} tracks total", album.tracks.len());
 }
 


### PR DESCRIPTION
## Description

Add progress prints. Looks like this:

<img width="1721" height="1367" alt="image" src="https://github.com/user-attachments/assets/d2fc8b5a-3922-4ac5-994f-e652d3097e6e" />

It can be improved, but I think it is informative enough. For now there is no silent/verbose mode options.

## Reference

Closes #15 