### PR TITLE
fix wrong MusicBrainz response parsing

### DIFF
--- a/src/music_brainz/fetch_metadata.rs
+++ b/src/music_brainz/fetch_metadata.rs
@@ -29,7 +29,6 @@ pub struct CoverArtArchive {
 #[derive(Debug, Deserialize)]
 pub struct Medium {
     pub format: Option<String>, // "CD", etc.
-    #[serde(rename = "track-count")]
     pub tracks: Option<Vec<Track>>,
 }
 


### PR DESCRIPTION
## Description

When cleaning up unused fields, I accidentally kept a serde JSON renaming rule, which broke the parsing logic.