### PR TITLE
Add progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cd-da-reader"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534300c381b8a66845e47e0b3175d98d65be96bf8b8397a8d056f4bfd2bc09a0"
+checksum = "427d049991349046b00a9f13ef38b93cefe32da9a1de5a147dfebaa5f045a1dd"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["target", "Cargo.lock"]
 
 [dependencies]
 base64 = "0.22.1"
-cd-da-reader = "0.2.1"
+cd-da-reader = "0.3.1"
 flac-codec = "1.1.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"

--- a/src/album_writer.rs
+++ b/src/album_writer.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::music_brainz::{Album, AlbumTrack};
-use cd_da_reader::{CdReader, Toc};
+use cd_da_reader::{CdReader, Toc, TrackStreamConfig};
 
 use flac_codec::{
     byteorder::LittleEndian,
@@ -95,7 +95,7 @@ pub fn write_album(
     for (track_num, track) in tracks_to_rip {
         println!("Writing a track #{}: {}", track_num, &track.title);
 
-        match reader.read_track(toc, track_num) {
+        match read_track_with_progress(reader, toc, track_num) {
             Ok(track_data) => save_raw_data_as_flac(
                 new_dir.join(sanitize_title(&track.title)),
                 track_data,
@@ -149,6 +149,66 @@ pub fn write_album(
     Ok(())
 }
 
+fn read_track_with_progress(
+    reader: &CdReader,
+    toc: &Toc,
+    track_num: u8,
+) -> std::result::Result<Vec<u8>, cd_da_reader::CdReaderError> {
+    const CDDA_SECTOR_BYTES: usize = 2352;
+
+    let mut stream = reader.open_track_stream(toc, track_num, TrackStreamConfig::default())?;
+    let total_sectors = stream.total_sectors();
+    let total_secs = stream.total_seconds();
+    let mut data = Vec::with_capacity(total_sectors as usize * CDDA_SECTOR_BYTES);
+    let mut printed_progress = false;
+
+    loop {
+        match stream.next_chunk() {
+            Ok(Some(chunk)) => {
+                data.extend_from_slice(&chunk);
+                print_read_progress(stream.current_seconds(), total_secs);
+                printed_progress = true;
+            }
+            Ok(None) => break,
+            Err(error) => {
+                if printed_progress {
+                    eprintln!();
+                }
+
+                return Err(error);
+            }
+        }
+    }
+
+    print_read_progress(total_secs, total_secs);
+    eprintln!();
+
+    Ok(data)
+}
+
+fn print_read_progress(current_secs: f32, total_secs: f32) {
+    let percent = if total_secs > 0.0 {
+        current_secs / total_secs * 100.0
+    } else {
+        100.0
+    };
+
+    eprint!(
+        "\r  Reading: [{} / {}] {:5.1}%",
+        format_duration(current_secs),
+        format_duration(total_secs),
+        percent.min(100.0)
+    );
+}
+
+fn format_duration(seconds: f32) -> String {
+    let total_seconds = seconds.round() as u32;
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+
+    format!("{minutes:02}:{seconds:02}")
+}
+
 fn save_raw_data_as_flac(
     file_path: PathBuf,
     data: Vec<u8>,
@@ -166,6 +226,8 @@ fn save_raw_data_as_flac(
     let sample_rate = 44_100u32;
     let bits_per_sample = 16u32;
     let channels = 2u8;
+
+    println!("Encoding to FLAC...");
 
     {
         let mut flac_writer: FlacByteWriter<std::io::BufWriter<fs::File>, LittleEndian> =

--- a/src/album_writer.rs
+++ b/src/album_writer.rs
@@ -93,17 +93,19 @@ pub fn write_album(
     let mut failed_tracks: Vec<(u8, String)> = Vec::new();
 
     for (track_num, track) in tracks_to_rip {
-        println!("Writing a track #{}: {}", track_num, &track.title);
+        println!("\nWriting a track #{}: {}", track_num, &track.title);
 
-        match read_track_with_progress(reader, toc, track_num) {
-            Ok(track_data) => save_raw_data_as_flac(
-                new_dir.join(sanitize_title(&track.title)),
-                track_data,
-                track,
-                album,
-            ),
+        match write_track_as_flac_with_progress(
+            new_dir.join(sanitize_title(&track.title)),
+            reader,
+            toc,
+            track_num,
+            track,
+            album,
+        ) {
+            Ok(_) => {}
             Err(error) => {
-                println!("Could not read track #{}, {}", track_num, &track.title);
+                println!("Could not write track #{}, {}", track_num, &track.title);
                 println!("Error: {:#?}", error);
                 failed_tracks.push((track_num, track.title.clone()));
                 continue;
@@ -111,15 +113,15 @@ pub fn write_album(
         };
 
         println!(
-            "Successfully wrote the track #{}: {}",
+            "\r  Successfully wrote the track #{}: {}",
             track_num, &track.title
         );
     }
 
     if failed_tracks.is_empty() {
-        println!("All tracks were read successfully");
+        println!("All tracks were written successfully");
     } else {
-        println!("Failed to read {} track(s):", failed_tracks.len());
+        println!("Failed to write {} track(s):", failed_tracks.len());
         for (track_num, track_title) in &failed_tracks {
             println!("#{} {}", track_num, track_title);
         }
@@ -149,24 +151,87 @@ pub fn write_album(
     Ok(())
 }
 
-fn read_track_with_progress(
+fn write_track_as_flac_with_progress(
+    file_path: PathBuf,
     reader: &CdReader,
     toc: &Toc,
     track_num: u8,
-) -> std::result::Result<Vec<u8>, cd_da_reader::CdReaderError> {
+    track: &AlbumTrack,
+    album: &Album,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let file = file_path.with_extension("flac");
+
+    if file.exists() {
+        println!("File {} already exists", file.display());
+        return Ok(());
+    }
+
+    let temp_file = file.with_extension("flac.tmp");
+    if temp_file.exists() {
+        fs::remove_file(&temp_file)?;
+    }
+
+    let result = (|| -> std::result::Result<(), Box<dyn std::error::Error>> {
+        write_track_to_temp_flac(&temp_file, reader, toc, track_num)?;
+        update_track_metadata(&temp_file, track, album)?;
+        println!("\r  Successfully added metadata");
+        fs::rename(&temp_file, &file)?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_file);
+    }
+
+    result
+}
+
+fn write_track_to_temp_flac(
+    file: &Path,
+    reader: &CdReader,
+    toc: &Toc,
+    track_num: u8,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
     const CDDA_SECTOR_BYTES: usize = 2352;
 
     let mut stream = reader.open_track_stream(toc, track_num, TrackStreamConfig::default())?;
     let total_sectors = stream.total_sectors();
     let total_secs = stream.total_seconds();
-    let mut data = Vec::with_capacity(total_sectors as usize * CDDA_SECTOR_BYTES);
+    let total_bytes = u64::from(total_sectors) * CDDA_SECTOR_BYTES as u64;
     let mut printed_progress = false;
+
+    // CD-DA: 44_100 Hz, 16-bit, 2 channels
+    let sample_rate = 44_100u32;
+    let bits_per_sample = 16u32;
+    let channels = 2u8;
+    let total_bytes = if total_bytes == 0 {
+        None
+    } else {
+        Some(total_bytes)
+    };
+
+    let mut flac_writer: FlacByteWriter<std::io::BufWriter<fs::File>, LittleEndian> =
+        FlacByteWriter::create(
+            file,
+            Options::best(),
+            sample_rate,
+            bits_per_sample,
+            channels,
+            total_bytes,
+        )?;
 
     loop {
         match stream.next_chunk() {
             Ok(Some(chunk)) => {
-                data.extend_from_slice(&chunk);
-                print_read_progress(stream.current_seconds(), total_secs);
+                if let Err(error) = flac_writer.write_all(&chunk) {
+                    if printed_progress {
+                        eprintln!();
+                    }
+
+                    return Err(error.into());
+                }
+
+                print_rip_progress(stream.current_seconds(), total_secs);
                 printed_progress = true;
             }
             Ok(None) => break,
@@ -175,18 +240,23 @@ fn read_track_with_progress(
                     eprintln!();
                 }
 
-                return Err(error);
+                return Err(error.into());
             }
         }
     }
 
-    print_read_progress(total_secs, total_secs);
+    print_rip_progress(total_secs, total_secs);
+
+    if let Err(error) = flac_writer.finalize() {
+        eprintln!();
+        return Err(error.into());
+    }
     eprintln!();
 
-    Ok(data)
+    Ok(())
 }
 
-fn print_read_progress(current_secs: f32, total_secs: f32) {
+fn print_rip_progress(current_secs: f32, total_secs: f32) {
     let percent = if total_secs > 0.0 {
         current_secs / total_secs * 100.0
     } else {
@@ -194,7 +264,7 @@ fn print_read_progress(current_secs: f32, total_secs: f32) {
     };
 
     eprint!(
-        "\r  Reading: [{} / {}] {:5.1}%",
+        "\r  Reading and encoding: [{} / {}] {:5.1}%",
         format_duration(current_secs),
         format_duration(total_secs),
         percent.min(100.0)
@@ -207,55 +277,6 @@ fn format_duration(seconds: f32) -> String {
     let seconds = total_seconds % 60;
 
     format!("{minutes:02}:{seconds:02}")
-}
-
-fn save_raw_data_as_flac(
-    file_path: PathBuf,
-    data: Vec<u8>,
-    track: &AlbumTrack,
-    album: &Album,
-) -> Option<()> {
-    let file = file_path.with_extension("flac");
-
-    if file.exists() {
-        println!("File {} already exists", file.display());
-        return None;
-    }
-
-    // CD-DA: 44_100 Hz, 16-bit, 2 channels
-    let sample_rate = 44_100u32;
-    let bits_per_sample = 16u32;
-    let channels = 2u8;
-
-    println!("Encoding to FLAC...");
-
-    {
-        let mut flac_writer: FlacByteWriter<std::io::BufWriter<fs::File>, LittleEndian> =
-            FlacByteWriter::create(
-                &file,
-                Options::best(),
-                sample_rate,
-                bits_per_sample,
-                channels,
-                None,
-            )
-            .unwrap();
-
-        flac_writer.write_all(&data).ok()?;
-
-        flac_writer.finalize().ok()?;
-    }
-
-    match update_track_metadata(&file, track, album) {
-        Ok(_) => {
-            println!("Successfully added metadata");
-        }
-        Err(flac_error) => {
-            println!("{:#?}", flac_error);
-        }
-    };
-
-    Some(())
 }
 
 fn update_track_metadata(


### PR DESCRIPTION
## Description

Adds multiple improvements.

First, it changes from reading the file and then encoding it to using streams for both. Second, it prints the progress, so you can see how it is going.

## Reference

Closes https://github.com/Bloomca/audio-cd-ripper/issues/32