### PR TITLE
More robust MusicBrainz ID calculation

### DIFF
--- a/src/album_writer.rs
+++ b/src/album_writer.rs
@@ -93,7 +93,7 @@ pub fn write_album(
     let mut failed_tracks: Vec<(u8, String)> = Vec::new();
 
     for (track_num, track) in tracks_to_rip {
-        println!("\nWriting a track #{}: {}", track_num, &track.title);
+        println!("\nWriting track #{}: {}", track_num, &track.title);
 
         match write_track_as_flac_with_progress(
             new_dir.join(sanitize_title(&track.title)),

--- a/src/music_brainz/calculate_id.rs
+++ b/src/music_brainz/calculate_id.rs
@@ -1,11 +1,19 @@
 use base64::{Engine as _, engine::general_purpose};
 use sha1::{Digest, Sha1};
 
-use cd_da_reader::Toc;
+use cd_da_reader::{Toc, Track};
+
+const CD_EXTRA_SESSION_GAP_FRAMES: u32 = 11_400;
+
+pub struct MusicBrainzDisc {
+    pub id: String,
+    pub toc_query: String,
+}
 
 /// read more about the algorithm here: https://musicbrainz.org/doc/Disc_ID_Calculation
-pub fn calculate_music_brainz_id(toc: &Toc) -> String {
-    let toc_string = format_toc_string(toc);
+pub fn calculate_music_brainz_disc(toc: &Toc) -> MusicBrainzDisc {
+    let toc_data = music_brainz_toc_data(toc);
+    let toc_string = format_toc_string(&toc_data);
 
     let mut hasher = Sha1::new();
     hasher.update(toc_string.as_bytes());
@@ -14,14 +22,61 @@ pub fn calculate_music_brainz_id(toc: &Toc) -> String {
     let base64_result = general_purpose::STANDARD.encode(hash_result);
 
     // Convert to MusicBrainz format: replace + with . and / with _, remove padding
-    base64_result
+    let id = base64_result
         .replace('+', ".")
         .replace('/', "_")
         .replace('=', "-")
-        .to_string()
+        .to_string();
+
+    MusicBrainzDisc {
+        id,
+        toc_query: format_toc_query(&toc_data),
+    }
 }
 
-fn format_toc_string(toc: &Toc) -> String {
+struct MusicBrainzTocData<'a> {
+    first_track: u8,
+    last_track: u8,
+    leadout_lba: u32,
+    tracks: Vec<&'a Track>,
+}
+
+fn music_brainz_toc_data(toc: &Toc) -> MusicBrainzTocData<'_> {
+    let audio_tracks: Vec<&Track> = toc.tracks.iter().filter(|track| track.is_audio).collect();
+
+    if audio_tracks.is_empty() {
+        return MusicBrainzTocData {
+            first_track: toc.first_track,
+            last_track: toc.last_track,
+            leadout_lba: toc.leadout_lba,
+            tracks: toc.tracks.iter().collect(),
+        };
+    }
+
+    let first_audio_track = audio_tracks.first().expect("audio_tracks is not empty");
+    let last_audio_track = audio_tracks.last().expect("audio_tracks is not empty");
+    let first_data_track_after_audio = toc
+        .tracks
+        .iter()
+        .filter(|track| !track.is_audio && track.start_lba > last_audio_track.start_lba)
+        .min_by_key(|track| track.start_lba);
+
+    let leadout_lba = match first_data_track_after_audio {
+        Some(data_track) => data_track
+            .start_lba
+            .saturating_sub(CD_EXTRA_SESSION_GAP_FRAMES),
+        None => toc.leadout_lba,
+    };
+
+    MusicBrainzTocData {
+        first_track: first_audio_track.number,
+        last_track: last_audio_track.number,
+        leadout_lba,
+        tracks: audio_tracks,
+    }
+}
+
+fn format_toc_string(toc: &MusicBrainzTocData<'_>) -> String {
     let mut toc_string = String::new();
 
     // Add first track number (2 hex digits, uppercase)
@@ -46,4 +101,97 @@ fn format_toc_string(toc: &Toc) -> String {
     }
 
     toc_string
+}
+
+fn format_toc_query(toc: &MusicBrainzTocData<'_>) -> String {
+    let mut parts = Vec::with_capacity(toc.tracks.len() + 3);
+    parts.push(toc.first_track.to_string());
+    parts.push(toc.last_track.to_string());
+    parts.push((toc.leadout_lba + 150).to_string());
+
+    for track in &toc.tracks {
+        parts.push((track.start_lba + 150).to_string());
+    }
+
+    parts.join("+")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{calculate_music_brainz_disc, calculate_music_brainz_id};
+    use cd_da_reader::{Toc, Track};
+
+    #[test]
+    fn calculates_official_music_brainz_audio_cd_example() {
+        let toc = toc(
+            1,
+            6,
+            95_312,
+            &[
+                (1, 0, true),
+                (2, 15_213, true),
+                (3, 32_164, true),
+                (4, 46_442, true),
+                (5, 63_264, true),
+                (6, 80_339, true),
+            ],
+        );
+
+        assert_eq!(
+            calculate_music_brainz_id(&toc),
+            "49HHV7Eb8UKF3aQiNmu1GR8vKTY-"
+        );
+    }
+
+    #[test]
+    fn excludes_cd_extra_data_track_and_adjusts_audio_leadout() {
+        let toc = toc(
+            1,
+            16,
+            327_708,
+            &[
+                (1, 0, true),
+                (2, 4_510, true),
+                (3, 18_410, true),
+                (4, 36_447, true),
+                (5, 55_493, true),
+                (6, 71_048, true),
+                (7, 87_017, true),
+                (8, 110_864, true),
+                (9, 128_019, true),
+                (10, 143_293, true),
+                (11, 161_480, true),
+                (12, 178_164, true),
+                (13, 196_219, true),
+                (14, 216_169, true),
+                (15, 233_727, true),
+                (16, 263_053, false),
+            ],
+        );
+
+        let disc = calculate_music_brainz_disc(&toc);
+
+        assert_eq!(disc.id, "c5wj9buAu_oxDzVSQzCo3ySEGxs-");
+        assert_eq!(
+            disc.toc_query,
+            "1+15+251803+150+4660+18560+36597+55643+71198+87167+111014+128169+143443+161630+178314+196369+216319+233877"
+        );
+    }
+
+    fn toc(first_track: u8, last_track: u8, leadout_lba: u32, tracks: &[(u8, u32, bool)]) -> Toc {
+        Toc {
+            first_track,
+            last_track,
+            leadout_lba,
+            tracks: tracks
+                .iter()
+                .map(|(number, start_lba, is_audio)| Track {
+                    number: *number,
+                    start_lba: *start_lba,
+                    start_msf: (0, 0, 0),
+                    is_audio: *is_audio,
+                })
+                .collect(),
+        }
+    }
 }

--- a/src/music_brainz/calculate_id.rs
+++ b/src/music_brainz/calculate_id.rs
@@ -118,7 +118,7 @@ fn format_toc_query(toc: &MusicBrainzTocData<'_>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{calculate_music_brainz_disc, calculate_music_brainz_id};
+    use super::calculate_music_brainz_disc;
     use cd_da_reader::{Toc, Track};
 
     #[test]
@@ -138,7 +138,7 @@ mod tests {
         );
 
         assert_eq!(
-            calculate_music_brainz_id(&toc),
+            calculate_music_brainz_disc(&toc).id,
             "49HHV7Eb8UKF3aQiNmu1GR8vKTY-"
         );
     }

--- a/src/music_brainz/fetch_metadata.rs
+++ b/src/music_brainz/fetch_metadata.rs
@@ -95,12 +95,25 @@ impl MusicBrainzClient {
     fn lookup_by_disc_id(
         &self,
         id: &str,
+        toc_query: &str,
         includes: &[&str],
     ) -> Result<MusicBrainzResponse, MusicBrainzError> {
         let mut url: String = format!("https://musicbrainz.org/ws/2/discid/{}", id);
+        let mut query_params = Vec::new();
 
         if !includes.is_empty() {
-            url.push_str(&format!("?inc={}", includes.join("+")));
+            query_params.push(format!("inc={}", includes.join("+")));
+        }
+
+        if !toc_query.is_empty() {
+            query_params.push(format!("toc={toc_query}"));
+            query_params.push("cdstubs=no".to_string());
+            query_params.push("media-format=all".to_string());
+        }
+
+        if !query_params.is_empty() {
+            url.push('?');
+            url.push_str(&query_params.join("&"));
         }
 
         let response = self
@@ -116,13 +129,13 @@ impl MusicBrainzClient {
     }
 
     pub fn lookup_metadata(&self, toc: &Toc) -> Option<Album> {
-        let id = calculate_id::calculate_music_brainz_id(toc);
+        let disc = calculate_id::calculate_music_brainz_disc(toc);
 
-        println!("MusicBrainzId: {id}");
+        println!("MusicBrainzId: {}", disc.id);
 
         let includes: Vec<&str> = vec!["recordings", "artist-credits", "genres"];
 
-        let result = self.lookup_by_disc_id(&id, &includes);
+        let result = self.lookup_by_disc_id(&disc.id, &disc.toc_query, &includes);
 
         match result {
             Ok(response) => self.parse_metadata(&response),
@@ -170,7 +183,7 @@ impl MusicBrainzClient {
         Some(album)
     }
 
-    /// for now, find the first CD media and return it
+    /// for now, find the first CD-like media and return it
     fn find_cd_media<'a>(&self, media: &'a Option<Vec<Medium>>) -> Option<&'a Medium> {
         let Some(mediums) = media else {
             return None;
@@ -178,7 +191,7 @@ impl MusicBrainzClient {
 
         for medium in mediums {
             if let Some(medium_format) = &medium.format
-                && medium_format == "CD"
+                && is_cd_media_format(medium_format)
             {
                 return Some(medium);
             }
@@ -246,6 +259,10 @@ impl MusicBrainzClient {
         genres.dedup();
         genres
     }
+}
+
+fn is_cd_media_format(format: &str) -> bool {
+    format.contains("CD")
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Description

Enhanced CDs can have last track as data and not audio, so we can't just utilize the leadout LBA from it (we'd need to get the last audio track value). This fixes this problem.

Multi-CDs are still not handled, will add that in the future (hopefully 😅 )

## Reference

After this fix, https://github.com/Bloomca/audio-cd-ripper/issues/29 should not be relevant anymore. So, fixes https://github.com/Bloomca/audio-cd-ripper/issues/29.